### PR TITLE
Fix error when ngOnDestroy() is called but not ngOnInit()

### DIFF
--- a/module/ladda.directive.ts
+++ b/module/ladda.directive.ts
@@ -60,7 +60,8 @@ export class LaddaDirective implements OnInit, OnDestroy, OnChanges {
     }
 
     ngOnDestroy() {
-        this._ladda.remove();
+		if(this._ladda)
+			this._ladda.remove();
     }
 
     private updateLadda(previousValue: laddaValue): void {

--- a/module/ladda.directive.ts
+++ b/module/ladda.directive.ts
@@ -60,8 +60,11 @@ export class LaddaDirective implements OnInit, OnDestroy, OnChanges {
     }
 
     ngOnDestroy() {
-		if(this._ladda)
-			this._ladda.remove();
+        if (!this._ladda) {
+            return;
+        }
+		
+		this._ladda.remove();
     }
 
     private updateLadda(previousValue: laddaValue): void {

--- a/module/ladda.directive.ts
+++ b/module/ladda.directive.ts
@@ -60,11 +60,9 @@ export class LaddaDirective implements OnInit, OnDestroy, OnChanges {
     }
 
     ngOnDestroy() {
-        if (!this._ladda) {
-            return;
+        if (this._ladda) {
+            this._ladda.remove();
         }
-		
-		this._ladda.remove();
     }
 
     private updateLadda(previousValue: laddaValue): void {


### PR DESCRIPTION
Then can occur when navigating to a different route before the component is completely initialized.

Closes #27.