### PR TITLE
enhance - package.json : permisive peerDependencies version

### DIFF
--- a/projects/ladda/package.json
+++ b/projects/ladda/package.json
@@ -23,8 +23,8 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@angular/common": "^12.0.0",
-    "@angular/core": "^12.0.0",
+    "@angular/common": ">=12.0.0 <14.0.0",
+    "@angular/core": ">=12.0.0 <14.0.0",
     "ladda": "^2.0.1"
   },
   "dependencies": {


### PR DESCRIPTION
Change the accepted version from the `peerDependencies` to avoid having to --force it while using it in a v13 project